### PR TITLE
feat: add linter and formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI (PR)
+
+on:
+  pull_request:
+
+jobs:
+    lint:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4.1.3
+            - uses: actions/setup-python@v5.1.0
+              with:
+                python-version: 3.10
+            - run: pip install -r requirements.txt
+            - run: ruff check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,10 @@ on:
 jobs:
     lint:
         runs-on: ubuntu-latest
-        strategy:
-          matrix:
-            python-version: [3.10, 3.11, 3.12]
         steps:
             - uses: actions/checkout@v4.1.3
             - uses: actions/setup-python@v5.1.0
               with:
-                python-version: ${{ matrix.python-version }}
+                python-version: '3.10'
             - run: pip install -r requirements.txt
             - run: ruff check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,13 @@ on:
 jobs:
     lint:
         runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            python-version: [3.10, 3.11, 3.12]
         steps:
             - uses: actions/checkout@v4.1.3
             - uses: actions/setup-python@v5.1.0
               with:
-                python-version: 3.10
+                python-version: ${{ matrix.python-version }}
             - run: pip install -r requirements.txt
             - run: ruff check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.4.1
+    hooks:
+      # Run the formatter.
+      - id: ruff-format
+        name: Ruff Format Code

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ A instalação recomendada é usando um [ambiente virtual (venv)](https://docs.p
 
 O banco de dados utilizado é o [sqlite3](https://www.sqlite.org/).
 
+É utilizado o pre-commit para formatar o código, para iniciar ele rode:
+
+    pre-commit install
+
 ### Rodando o projeto
 
 Para rodar o portal, você vai precisar de três comando (todos rodados a partir da raíz do projeto):

--- a/build.py
+++ b/build.py
@@ -2,12 +2,12 @@
 
 import hashlib
 import json
-import requests
 import math
 import os
-
 from datetime import datetime
 from io import BytesIO
+
+import requests
 from PIL import Image
 
 from scrapers.imdb import IMDBScrapper

--- a/cinemaempoa.py
+++ b/cinemaempoa.py
@@ -4,9 +4,9 @@ import json
 import os
 import re
 import shutil
+from datetime import datetime
 
 from bs4 import BeautifulSoup
-from datetime import datetime
 
 from build import HtmlBuilder
 from scrapers.capitolio import Capitolio
@@ -14,7 +14,6 @@ from scrapers.cinebancarios import CineBancarios
 from scrapers.paulo_amorim import CinematecaPauloAmorim
 from scrapers.sala_redencao import SalaRedencao
 from utils import dump_utf8_json
-
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -69,9 +68,7 @@ if __name__ == "__main__":
 
     if args.rooms:
         if not all(room in allowed_rooms for room in args.rooms):
-            parser.error(
-                f"Invalid selected rooms. Available: {', '.join(allowed_rooms)}"
-            )
+            parser.error(f"Invalid selected rooms. Available: {', '.join(allowed_rooms)}")
 
         scrape_date = args.date
         if scrape_date:

--- a/flask_backend/db.py
+++ b/flask_backend/db.py
@@ -6,9 +6,7 @@ from sqlalchemy.orm import declarative_base, scoped_session, sessionmaker
 from flask_backend.env_config import ADMIN_PROD_PWD, ADMIN_PROD_USERNAME, DATABASE_URL
 
 engine = create_engine(DATABASE_URL)
-db_session = scoped_session(
-    sessionmaker(autocommit=False, autoflush=False, bind=engine)
-)
+db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
 
 Base = declarative_base()
 Base.query = db_session.query_property()
@@ -25,9 +23,7 @@ def seed_db_prod():
 
     print("Setting up admin user")
     try:
-        user_seeds.create_user_from_data(
-            db_session, ADMIN_PROD_USERNAME, ADMIN_PROD_PWD
-        )
+        user_seeds.create_user_from_data(db_session, ADMIN_PROD_USERNAME, ADMIN_PROD_PWD)
     except IntegrityError:
         db_session.rollback()
         print("Admin user already exists. Skipping...")

--- a/flask_backend/import_json.py
+++ b/flask_backend/import_json.py
@@ -68,7 +68,5 @@ class ScrappedResult:
     @classmethod
     def from_jsonable(cls, scrapped_results: str):
         return cls(
-            cinemas=[
-                ScrappedCinema.from_jsonable(cinema) for cinema in scrapped_results
-            ]
+            cinemas=[ScrappedCinema.from_jsonable(cinema) for cinema in scrapped_results]
         )

--- a/flask_backend/repository/cinemas.py
+++ b/flask_backend/repository/cinemas.py
@@ -1,5 +1,6 @@
-from sqlalchemy import asc
 from typing import List, Optional
+
+from sqlalchemy import asc
 
 from flask_backend.db import db_session
 from flask_backend.models import Cinema

--- a/flask_backend/repository/movies.py
+++ b/flask_backend/repository/movies.py
@@ -1,7 +1,5 @@
 from typing import List, Optional
 
-from sqlalchemy.orm import aliased
-
 from flask_backend.db import db_session
 from flask_backend.models import Movie, Screening
 
@@ -17,7 +15,7 @@ def create(title: str) -> Movie:
 def get_all(include_drafts: bool = False) -> List[Optional[Movie]]:
     query = db_session.query(Movie).join(Screening)
     if include_drafts is False:
-        query = query.filter(Screening.draft == False)
+        query = query.filter(Screening.draft is False)
     return query.all()
 
 

--- a/flask_backend/routes/auth.py
+++ b/flask_backend/routes/auth.py
@@ -35,11 +35,9 @@ def register():
 
         if error is None:
             try:
-                user = users_repository.create(
-                    username, generate_password_hash(password)
-                )
+                user = users_repository.create(username, generate_password_hash(password))
             except IntegrityError:
-                error = f"Nome de usuário inválido. Tente um nome diferente."
+                error = "Nome de usuário inválido. Tente um nome diferente."
             else:
                 welcome_message = Markup(
                     f"Boas vindas, <strong>{user.username}</strong>!"

--- a/flask_backend/routes/movie.py
+++ b/flask_backend/routes/movie.py
@@ -1,7 +1,9 @@
 from flask import Blueprint, g, jsonify, render_template, request
 
-from flask_backend.repository.movies import get_all as get_all_movies
-from flask_backend.repository.movies import get_movies_with_similar_titles
+from flask_backend.repository.movies import (
+    get_all as get_all_movies,
+    get_movies_with_similar_titles,
+)
 from flask_backend.routes.auth import login_required
 
 bp = Blueprint("movie", __name__)
@@ -11,9 +13,7 @@ bp = Blueprint("movie", __name__)
 def index():
     user_logged_in = g.user is not None
     movies = get_all_movies(user_logged_in)
-    return render_template(
-        "movie/index.html", movies=movies, show_drafts=user_logged_in
-    )
+    return render_template("movie/index.html", movies=movies, show_drafts=user_logged_in)
 
 
 @bp.route("/movies/search", methods=["GET"])

--- a/flask_backend/routes/screening.py
+++ b/flask_backend/routes/screening.py
@@ -16,21 +16,23 @@ from flask import (
 )
 from werkzeug.exceptions import abort
 
-from flask_backend.import_json import ScrappedCinema, ScrappedFeature, ScrappedResult
+from flask_backend.import_json import ScrappedResult
 from flask_backend.models import Screening
-from flask_backend.repository.cinemas import get_all as get_all_cinemas
-from flask_backend.repository.cinemas import get_by_id as get_cinema_by_id
-from flask_backend.repository.cinemas import get_by_slug as get_cinema_by_slug
+from flask_backend.repository.cinemas import (
+    get_all as get_all_cinemas,
+    get_by_id as get_cinema_by_id,
+    get_by_slug as get_cinema_by_slug,
+)
 from flask_backend.repository.movies import (
     get_by_title_or_create as get_movie_by_title_or_create,
 )
-from flask_backend.repository.screenings import create as create_screening
 from flask_backend.repository.screenings import (
+    create as create_screening,
     get_days_screenings_by_cinema_id,
     get_screening_by_id,
+    update as update_screening,
+    update_screening_dates,
 )
-from flask_backend.repository.screenings import update as update_screening
-from flask_backend.repository.screenings import update_screening_dates
 from flask_backend.routes.auth import login_required
 from flask_backend.service.screening import (
     build_dates,
@@ -248,9 +250,7 @@ def update(id):
         if movie_poster and movie_poster.filename:
             img_is_valid, message = validate_image(movie_poster)
             if img_is_valid:
-                new_img, image_width, image_height = save_image(
-                    movie_poster, current_app
-                )
+                new_img, image_width, image_height = save_image(movie_poster, current_app)
                 image = new_img
             else:
                 error = message

--- a/flask_backend/seeds/screening_seeds.py
+++ b/flask_backend/seeds/screening_seeds.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from faker import Faker
 
 from flask_backend.models import Screening, ScreeningDate

--- a/flask_backend/service/screening.py
+++ b/flask_backend/service/screening.py
@@ -15,11 +15,11 @@ from flask_backend.repository.cinemas import get_by_slug as get_cinema_by_slug
 from flask_backend.repository.movies import (
     get_by_title_or_create as get_movie_by_title_or_create,
 )
-from flask_backend.repository.screenings import create as create_screening
 from flask_backend.repository.screenings import (
+    create as create_screening,
     get_by_movie_id_and_cinema_id as get_screening_by_movie_id_and_cinema_id,
+    update_screening_dates,
 )
-from flask_backend.repository.screenings import update_screening_dates
 
 ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg"}
 
@@ -45,7 +45,7 @@ def validate_image(file) -> tuple[bool, str]:
             f"Extensão do arquivo inválida. Aceitamos {', '.join(ALLOWED_EXTENSIONS)}.",
         )
     if not _check_if_actually_image(file.stream):
-        return (False, f"Arquivo corrompido ou inválido.")
+        return (False, "Arquivo corrompido ou inválido.")
     return True, None
 
 
@@ -84,9 +84,7 @@ def download_image_from_url(image_url) -> Tuple[Optional[Image.Image], Optional[
     if image_url is None:
         return None, None
     file_extension = image_url.split(".")[-1]
-    file_name = (
-        hashlib.md5(image_url.encode("utf-8")).hexdigest() + "." + file_extension
-    )
+    file_name = hashlib.md5(image_url.encode("utf-8")).hexdigest() + "." + file_extension
 
     r = requests.get(image_url)
     if r.ok is False:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ Levenshtein==0.21.1
 MarkupSafe==2.1.5
 packaging==24.0
 Pillow==10.0.0
+pre-commit==3.7.0
 python-dateutil==2.9.0.post0
 python-decouple==3.8
 rapidfuzz==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ python-dateutil==2.9.0.post0
 python-decouple==3.8
 rapidfuzz==3.2.0
 requests==2.31.0
+ruff==0.3.7
 six==1.16.0
 soupsieve==2.4.1
 SQLAlchemy==2.0.29

--- a/ruff.toml
+++ b/ruff.toml
@@ -4,4 +4,7 @@ line-length = 90
 # Add the `line-too-long` rule to the enforced rule set. By default, Ruff omits rules that
 # overlap with the use of a formatter, like Black, but we can override this behavior by
 # explicitly adding the rule.
-extend-select = ["E501"]
+extend-select = ["I"]
+
+[lint.isort]
+combine-as-imports = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,7 @@
+line-length = 90
+
+[lint]
+# Add the `line-too-long` rule to the enforced rule set. By default, Ruff omits rules that
+# overlap with the use of a formatter, like Black, but we can override this behavior by
+# explicitly adding the rule.
+extend-select = ["E501"]

--- a/scrapers/capitolio.py
+++ b/scrapers/capitolio.py
@@ -1,9 +1,9 @@
 import os
 import re
-import requests
-
-from bs4 import BeautifulSoup
 from datetime import datetime
+
+import requests
+from bs4 import BeautifulSoup
 
 
 class Capitolio:
@@ -81,8 +81,8 @@ class Capitolio:
                 ".movie-info .movie-director"
             ).get_text()
             general_info = ""
-            for l in iter(movie_director.splitlines()):
-                line = l.strip()
+            for line in iter(movie_director.splitlines()):
+                line = line.strip()
                 if len(line) == 0:
                     continue
                 if line.startswith("Direção"):
@@ -104,9 +104,7 @@ class Capitolio:
             feature_film["excerpt"] = movie_text.get_text()
 
             read_more = movie.css.select_one(".movie-info .read-more")
-            feature_film["read_more"] = (
-                "http://www.capitolio.org.br" + read_more["href"]
-            )
+            feature_film["read_more"] = "http://www.capitolio.org.br" + read_more["href"]
             features.append(feature_film)
 
         return features

--- a/scrapers/cinebancarios.py
+++ b/scrapers/cinebancarios.py
@@ -1,12 +1,12 @@
 import os
 import re
-import requests
 import unicodedata
 import xml.etree.ElementTree as ET
+from datetime import datetime
 
+import requests
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString, ResultSet
-from datetime import datetime
 
 from utils import is_monday
 

--- a/scrapers/imdb.py
+++ b/scrapers/imdb.py
@@ -1,5 +1,4 @@
 import requests
-
 from bs4 import BeautifulSoup
 from country_list import countries_for_language
 from Levenshtein import distance
@@ -135,9 +134,9 @@ class IMDBScrapper:
         # TODO: attempt to get movie featured poster first,
         # sometimes images listed here are random stills
         # from the movie
-        image_poster_link = movie_soup.find(class_="hero-media__watchlist").findNext(
-            "a"
-        )["href"]
+        image_poster_link = movie_soup.find(class_="hero-media__watchlist").findNext("a")[
+            "href"
+        ]
 
         poster_request = requests.get(
             f"https://www.imdb.com/{image_poster_link}", headers=self.headers

--- a/scrapers/paulo_amorim.py
+++ b/scrapers/paulo_amorim.py
@@ -1,10 +1,10 @@
 import locale
 import os
-import requests
 import unicodedata
-
-from bs4 import BeautifulSoup
 from datetime import date, datetime, time as dt_time
+
+import requests
+from bs4 import BeautifulSoup
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
@@ -70,9 +70,7 @@ class CinematecaPauloAmorim:
         ticket_links = programacao_soup.css.select("a.link-default > .ticket")
         movies = []
         for ticket_link in ticket_links:
-            genre = ticket_link.css.select_one(".ticket-foto").css.select_one(
-                ".generos"
-            )
+            genre = ticket_link.css.select_one(".ticket-foto").css.select_one(".generos")
             if genre is not None:
                 genre = genre.text.strip("\n")
 

--- a/scrapers/sala_redencao.py
+++ b/scrapers/sala_redencao.py
@@ -1,11 +1,11 @@
 import os
 import re
-import requests
-
-from bs4 import BeautifulSoup
 from datetime import datetime
 
-from utils import get_formatted_day_str, string_is_current_day, string_is_day
+import requests
+from bs4 import BeautifulSoup
+
+from utils import get_formatted_day_str, string_is_day
 
 
 class SalaRedencao:

--- a/tests/scrapers/test_cinebancarios.py
+++ b/tests/scrapers/test_cinebancarios.py
@@ -1,9 +1,9 @@
 import os
-import pytest
 import sys
 import unicodedata
-
 import xml.etree.ElementTree as ET
+
+import pytest
 
 sys.path.insert(0, os.path.join(os.getcwd()))
 

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,4 @@
 import json
-
 from datetime import date, datetime
 
 


### PR DESCRIPTION
### Resolve
- #36 

### O que foi feito?

- Adiciona o Ruff como linter/formatter
- Adiciona o pre-commit afim de **formatar** o código usando o Ruff
- Adiciona workflow de CI a cada PR afim de rodar o linter usando o Ruff
- Arruma erros de lint no código
  PS: deixei alguns erros de próposito para validar o CI
  
### Pontos notáveis

#### Um pouco sobre a escolha do Ruff
A decisão de ter escolhido o Ruff como linter e formatter é devido aos seguintes pontos:

1. Ele é extremamente rápido

![image](https://github.com/guites/cinemaempoa/assets/97882083/685646c9-cdbf-4412-915f-27b259521c6c)

2. Ele é um linter e formatter, ou seja tudo em um, as principais ferramentas não são assim, se quisesse seguir o padrão pytônico teria que instalar o black (formatter), isort(formatter) e pylint (linter)
3. Ele dá suporte a todas as regras de formatacões de ferramentas famosas como o black (formatter), isort(formatter) e pylint (linter)

#### Um pouco sobre o funcionamento do Ruff

O Ruff é dividido em duas parte o Ruff Linter (ruff check) e o Ruff Formatter (ruff format)

![image](https://github.com/guites/cinemaempoa/assets/97882083/4531529d-cefe-4c49-8ecb-20ff4477325c)

![image](https://github.com/guites/cinemaempoa/assets/97882083/40db01e6-4646-4449-9f4e-2593df505a3c)

Além disso, todas as confiracões de lint/format ficam no arquivo ruff.toml