### PR TITLE
#60 uso de ia para gerar descricao de imagens

### DIFF
--- a/flask_backend/env_config.py
+++ b/flask_backend/env_config.py
@@ -8,4 +8,7 @@ APP_ENVIRONMENT = config("APP_ENVIRONMENT", default=EnvironmentEnum.DEVELOPMENT)
 ADMIN_PROD_USERNAME = config("ADMIN_PROD_USERNAME", default="cinemaempoa")
 ADMIN_PROD_PWD = config("ADMIN_PROD_PWD", default="secret-pwd")
 UPLOAD_DIR = config("UPLOAD_DIR", None)
-IMGBB_API_KEY = config("IMGBB_API_KEY", default="invalid-key") # api-key from https://api.imgbb.com/
+IMGBB_API_KEY = config(
+    "IMGBB_API_KEY", default="invalid-key"
+)  # api-key from https://api.imgbb.com/
+GEMINI_API_KEY = config("GEMINI_API_KEY", None)

--- a/flask_backend/models.py
+++ b/flask_backend/models.py
@@ -41,6 +41,7 @@ class Screening(Base):
     url = Column(String, nullable=True)
     # TODO: should image and description belong to the movie?
     image = Column(String, nullable=True)
+    image_alt = Column(String, nullable=True)
     description = Column(String, nullable=False)
     # TODO: maybe change this to a _status_ enum?
     draft = Column(Boolean, nullable=False, default=False)

--- a/flask_backend/repository/screenings.py
+++ b/flask_backend/repository/screenings.py
@@ -45,12 +45,14 @@ def create(
     image_width: Optional[int],
     image_height: Optional[int],
     is_draft: Optional[bool] = False,
+    image_alt: Optional[bool] = None,
 ) -> Screening:
     screening = Screening(
         movie_id=movie_id,
         cinema_id=cinema_id,
         dates=screening_dates,
         image=image,
+        image_alt=image_alt,
         image_width=image_width,
         image_height=image_height,
         description=description,

--- a/flask_backend/repository/screenings.py
+++ b/flask_backend/repository/screenings.py
@@ -86,10 +86,12 @@ def update(
     image_width: Optional[int],
     image_height: Optional[int],
     is_draft: Optional[bool] = False,
+    image_alt: Optional[str] = None,
 ) -> None:
     screening.movie_id = movie_id
     screening.description = description
     screening.draft = is_draft
+    screening.image_alt = image_alt
     if image:
         screening.image = image
         screening.image_width = image_width

--- a/flask_backend/routes/screening.py
+++ b/flask_backend/routes/screening.py
@@ -89,6 +89,7 @@ def index():
                 {
                     "times": screening_times,
                     "image": screening.image,
+                    "image_alt": screening.image_alt,
                     "min_height": minHeight,
                     "image_display_width": imgDisplayWidth,
                     "title": screening.movie.title,
@@ -122,6 +123,7 @@ def create():
         cinema_id = request.form.get("cinema_id")
         screening_dates = request.form.getlist("screening_dates")
         status = request.form.get("status")
+        image_alt = request.form.get("image_alt")
         error = None
 
         if not movie_title:
@@ -169,6 +171,7 @@ def create():
                 image_width,
                 image_height,
                 status == "draft",
+                image_alt,
             )
             flash(f"Sessão «{movie_title}» criada com sucesso!", "success")
             return redirect(url_for("screening.index"))
@@ -411,12 +414,12 @@ def describe_image():
     if request.method != "POST":
         abort(405)
     if "image" not in request.files:
-        jsonify({"details": "Imagem não encontrada."}), 400
+        return jsonify({"details": "Imagem não encontrada."}), 400
     image = request.files["image"]
     try:
         gemini = Gemini()
     except ValueError:
-        jsonify({"details": "Chave de API Gemini não configurada."}), 500
+        return jsonify({"details": "Chave de API Gemini não configurada."}), 500
 
     prompt_text = "Descreva essa imagem de forma a auxiliar uma pessoa com dificuldade de visão a entender o seu contexto, em português brasileiro."
     prompt_response = gemini.prompt_image(image, prompt_text)

--- a/flask_backend/routes/screening.py
+++ b/flask_backend/routes/screening.py
@@ -117,6 +117,7 @@ def upload(filename):
 @login_required
 def create():
     screening_dates = []
+    image = None
     if request.method == "POST":
         movie_title = request.form.get("movie_title")
         description = request.form.get("description")
@@ -147,7 +148,6 @@ def create():
             error = "Selecione uma sala de cinema disponível na listagem."
 
         movie_poster = request.files.get("movie_poster", None)
-        image = None
         image_width = None
         image_height = None
 
@@ -191,6 +191,7 @@ def create():
     return render_template(
         "screening/create.html",
         cinemas=cinemas,
+        image=image,
         current_date=current_date,
         received_dates=valid_dates,
         max_year=max_year,
@@ -225,7 +226,7 @@ def publish(id):
 @login_required
 def update(id):
     screening = get_screening_by_id(id)
-
+    image = screening.image
     if not screening:
         abort(404)
 
@@ -234,6 +235,7 @@ def update(id):
         description = request.form.get("description")
         screening_dates = request.form.getlist("screening_dates")
         status = request.form.get("status")
+        image_alt = request.form.get("image_alt")
         error = None
 
         if not movie_title:
@@ -279,11 +281,17 @@ def update(id):
                 image_width,
                 image_height,
                 status == "draft",
+                image_alt,
             )
             flash(f"Sessão «{movie_title}» atualizada com sucesso!", "success")
             return redirect(url_for("screening.index"))
 
-    return render_template("screening/update.html", screening=screening)
+    return render_template(
+        "screening/update.html",
+        screening=screening,
+        image=image,
+        max_file_size=current_app.config["MAX_CONTENT_LENGTH"],
+    )
 
 
 @bp.route("/screening/<int:id>/delete", methods=("POST",))

--- a/flask_backend/service/gemini_api.py
+++ b/flask_backend/service/gemini_api.py
@@ -1,0 +1,47 @@
+import base64
+
+import requests
+
+from flask_backend.env_config import GEMINI_API_KEY
+
+
+class Gemini:
+    """Interacts with google's Gemini API
+    https://ai.google.dev/gemini-api/docs"""
+
+    def __init__(self):
+        if GEMINI_API_KEY is None:
+            raise ValueError("Invalid Gemini API key")
+        self.headers = {"Content-Type": "application/json"}
+        self.api_key = GEMINI_API_KEY
+        self.models = {
+            "gemini-pro-vision": "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision"
+        }
+
+    def _get_url(self, model, resource):
+        return f"{self.models[model]}:{resource}?key={self.api_key}"
+
+    def prompt_image(self, image, text):
+        """Based on https://ai.google.dev/gemini-api/docs/get-started/rest#text-and-image_input"""
+        payload = {
+            "contents": [
+                {
+                    "parts": [
+                        {"text": text},
+                        {
+                            "inline_data": {
+                                "mime_type": "image/jpeg",
+                                "data": base64.b64encode(image.read()).decode("utf-8"),
+                            }
+                        },
+                    ]
+                }
+            ]
+        }
+        r = requests.post(
+            self._get_url("gemini-pro-vision", "generateContent"),
+            json=payload,
+            headers=self.headers,
+        )
+        r.raise_for_status()
+        return r.json()

--- a/flask_backend/templates/screening/create.html
+++ b/flask_backend/templates/screening/create.html
@@ -46,7 +46,7 @@
       <label for="movie_poster" class="form-label mb-0 me-3">Imagem do filme</label>
       <button type="button" id="gen-alt-btn"
       class="btn btn-secondary d-none"
-      onclick="fetchImageAltText()"
+      onclick="fetchImageAltText(event)"
       >
         Gerar alt text
       </button>
@@ -56,6 +56,15 @@
       <span id="file-limit-label"></span>
       <span class="text-danger d-block" id="errorMessage"></span>
     </p>
+  </div>
+  <div class="mb-3">
+      <label class="form-label" for="image_alt">Descrição do poster (texto alternativo)</label>
+      <textarea
+        placeholder="Descreva a imagem adicionada acima"
+        class="form-control"
+        name="image_alt"
+        id="image_alt"
+        ></textarea>
   </div>
   <div class="mb-3">
     <label class="form-label">Status do cadastro</label>
@@ -185,15 +194,45 @@
       }
   }
 
-  function fetchImageAltText() {
+  async function fetchImageAltText(e) {
+    const btn = e.target;
+    
     const image_input = document.getElementById("movie_poster");
+    const image_alt = document.getElementById("image_alt");
+    
+    // prevent accidental overwriting of existing
+    // image alt text
+    let confirmation = true;
+    if (image_alt.value != "") {
+      confirmation = confirm("Substituir descrição atual?");
+    }
+    if (!confirmation) {
+      return;
+    }
+
     const form = new FormData();
     form.append("image", image_input.files[0]);
-    
-    fetch("/screening/image/describe", {
+
+    btn.disabled = true;
+    const response = await fetch("/screening/image/describe", {
       method: "POST",
       body: form
     });
+    const payload = await response.json();
+
+    if (!response.ok) {
+      alert(payload.details);
+      if (payload.hasOwnProperty("info")) {
+        console.log(payload.info);
+      }
+    }
+
+    if (response.ok) {
+      image_alt.value = payload.text;
+    }
+
+    btn.disabled = false;
+
   }
 </script>
 {% endblock %}

--- a/flask_backend/templates/screening/create.html
+++ b/flask_backend/templates/screening/create.html
@@ -1,238 +1,103 @@
-{% extends 'base.html' %}
-
-{% block header %}
-  <h1>{% block title %}Criar sessão{% endblock %}</h1>
-  <p></p>
+{% extends 'base.html' %} {% block header %}
+<h1>{% block title %}Criar sessão{% endblock %}</h1>
 {% endblock %}
-
 {% block content %}
-<form method="post" enctype="multipart/form-data">
-  <div class="mb-3">
-    <label class="form-label" for="title">Cinema</label>
-    <select class="form-select" id="cinema_id" name="cinema_id">
-      <option {% if not request.form['cinema_id'] %} selected {% endif %}>Selecione uma sala</option>
-      {% for cinema in cinemas %}
-        <option value="{{ cinema.id }}"{% if request.form['cinema_id'] == cinema.id|string %} selected {% endif %}>{{ cinema.name }}</option>
-      {% endfor %}
-    </select>
-  </div>
-  <div class="mb-3" id="screenings">
-    <p>Exibições</p>
-    {% if received_dates|length %}
-      {% for received_date in received_dates %}
+    <form method="post" enctype="multipart/form-data">
+    <div class="mb-3">
+        <label class="form-label" for="title">Cinema</label>
+        <select class="form-select" id="cinema_id" name="cinema_id">
+        <option {% if not request.form['cinema_id'] %} selected {% endif %}>Selecione uma sala</option>
+        {% for cinema in cinemas %}
+            <option value="{{ cinema.id }}"{% if request.form['cinema_id'] == cinema.id|string %} selected {% endif %}>{{ cinema.name }}</option>
+        {% endfor %}
+        </select>
+    </div>
+    <div class="mb-3" id="screenings">
+        <p>Exibições</p>
+        {% if received_dates|length %}
+        {% for received_date in received_dates %}
+            <div class="mb-2">
+            <input class="form-control mb-1" type="datetime-local" name="screening_dates" value="{{received_date}}" min="2023-01-01T00:00" max="{{max_year}}-12-31T00:00" />
+            <button onclick="removeScreening(this)"  type="button" class="btn btn-sm">Remover</button>
+            </div>
+        {% endfor %}
+        {% else %}
         <div class="mb-2">
-          <input class="form-control mb-1" type="datetime-local" name="screening_dates" value="{{received_date}}" min="2023-01-01T00:00" max="{{max_year}}-12-31T00:00" />
-          <button onclick="removeScreening(this)"  type="button" class="btn btn-sm">Remover</button>
+            <input class="form-control mb-1" type="datetime-local" name="screening_dates" value="{{current_date}}T19:00" min="2023-01-01T00:00" max="{{max_year}}-12-31T00:00" />
+            <button onclick="removeScreening(this)"  type="button" class="btn btn-sm">Remover</button>
         </div>
-      {% endfor %}
-    {% else %}
-      <div class="mb-2">
-        <input class="form-control mb-1" type="datetime-local" name="screening_dates" value="{{current_date}}T19:00" min="2023-01-01T00:00" max="{{max_year}}-12-31T00:00" />
-        <button onclick="removeScreening(this)"  type="button" class="btn btn-sm">Remover</button>
-      </div>
-    {% endif %}
-  </div>
-  <div class="mb-3">
-    <button type="button" id="add-screening-btn" class="btn btn-secondary">Outra exibição</button>
-  </div>
-  <div class="mb-3">
-    <label class="form-label" for="title">Title</label>
-    <input autocomplete="off" class="form-control" name="movie_title" id="title" value="{{ request.form['movie_title'] }}" oninput="fetchSimilarTitles()" required>
-  </div>
-  <ul class="mb-3" class="" id="similar_movies">
-  </ul>
-  <div class="mb-3">
-    <div class="d-flex mb-2 align-items-center">
-      <label for="movie_poster" class="form-label mb-0 me-3">Imagem do filme</label>
-      <button type="button" id="gen-alt-btn"
-      class="btn btn-secondary d-none"
-      onclick="fetchImageAltText(event)"
-      >
-        Gerar alt text
-      </button>
+        {% endif %}
     </div>
-    <input class="form-control" name="movie_poster" type="file" id="movie_poster" onchange="verifyFileSize(this)" accept="image/*">
-    <p class="form-text">
-      <span id="file-limit-label"></span>
-      <span class="text-danger d-block" id="errorMessage"></span>
-    </p>
-  </div>
-  <div class="mb-3">
-      <label class="form-label" for="image_alt">Descrição do poster (texto alternativo)</label>
-      <textarea
-        placeholder="Descreva a imagem adicionada acima"
-        class="form-control"
-        name="image_alt"
-        id="image_alt"
-        >{{ request.form['image_alt'] }}</textarea>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Status do cadastro</label>
-    <div class="form-check">
-      <input class="form-check-input" type="radio" value="draft" name="status" id="status-draft">
-      <label class="form-check-label" for="status-draft">
-        Salvar rascunho
-      </label>
+    <div class="mb-3">
+        <button type="button" id="add-screening-btn" class="btn btn-secondary">Outra exibição</button>
     </div>
-    <div class="form-check">
-      <input class="form-check-input" type="radio" value="published" name="status" id="status-published" checked>
-      <label class="form-check-label" for="status-published">
-        Publicar
-      </label>
+    <div class="mb-3">
+        <label class="form-label" for="title">Title</label>
+        <input autocomplete="off" class="form-control" name="movie_title" id="title" value="{{ request.form['movie_title'] }}" oninput="fetchSimilarTitles()" required>
     </div>
-  </div>
-
-  <div class="mb-3">
-    <label class="form-label" for="screening-description">Body</label>
-    <div class="grow-wrap">
-      <textarea
-        class="form-control"
-        name="description"
-        id="screening-description"
-        >{{ request.form['description'] }}</textarea>
+    <ul class="mb-3" class="" id="similar_movies">
+    </ul>
+    <div class="mb-3">
+        <div class="d-flex mb-2 align-items-center">
+            <label for="movie_poster" class="form-label mb-0 me-3">Imagem do filme</label>
+            <button type="button" id="gen-alt-btn"
+            class="btn btn-secondary d-none"
+            onclick="fetchImageAltText(event)"
+            >
+                Gerar alt text
+            </button>
+        </div>
+        <input
+            class="form-control"
+            name="movie_poster"
+            type="file"
+            id="movie_poster"
+            onchange="verifyFileSize(this)" accept="image/*"
+        />
+        <p class="form-text">
+            <span id="file-limit-label"></span>
+            <span class="text-danger d-block" id="errorMessage"></span>
+        </p>
     </div>
-  </div>
-  <div class="container mb-3 pb-3">
-    <input class="btn btn-primary" type="submit" value="Save">
-    <a id="back-btn" class="btn btn-secondary" href="{{ url_for('screening.index') }}">Voltar</a>
-  </div>
-</form>
-<script>
-  function removeScreening(e) {
-    const screeningWrapper = document.getElementById("screenings");
-    if (screeningWrapper.childElementCount == 2) return;
-    e.parentElement.remove();
-  }
-  window.onload = () => {
-    const description = document.getElementById("screening-description");
-    description.style.height = `${description.scrollHeight}px`;
-    const backBtn = document.getElementById('back-btn');
-    backBtn.addEventListener("click", (e) => {
-      const proceed = confirm("Alterações não salvas serão perdidas. Prosseguir?");
-      if (!proceed) {
-        e.preventDefault();
-        return;
-      }
-    });
-    const addScreeningBtn = document.getElementById("add-screening-btn");
-    addScreeningBtn.addEventListener("click", (e) => {
-      const screeningWrapper = document.getElementById("screenings");
+    <div class="mb-3">
+        <label class="form-label" for="image_alt">Descrição do poster (texto alternativo)</label>
+        <textarea
+            placeholder="Descreva a imagem adicionada acima"
+            class="form-control"
+            name="image_alt"
+            id="image_alt"
+            >{{ request.form['image_alt'] }}</textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Status do cadastro</label>
+        <div class="form-check">
+        <input class="form-check-input" type="radio" value="draft" name="status" id="status-draft">
+        <label class="form-check-label" for="status-draft">
+            Salvar rascunho
+        </label>
+        </div>
+        <div class="form-check">
+        <input class="form-check-input" type="radio" value="published" name="status" id="status-published" checked>
+        <label class="form-check-label" for="status-published">
+            Publicar
+        </label>
+        </div>
+    </div>
 
-      const screeningDiv = screeningWrapper.lastElementChild;
-
-      const newScreeningDiv = screeningDiv.cloneNode(true);
-
-      screeningWrapper.appendChild(newScreeningDiv);
-    });
-    document.getElementById("file-limit-label").innerHTML = `Tamanho máximo de imagem de ${getMaxFileSize(true)}mb!`;
-  };
-
-  function getMaxFileSize(in_mb) {
-    const max_file_size_bytes = {{ max_file_size }};
-    if (in_mb) {
-      return max_file_size_bytes / 1024 / 1024;
-    }
-    return max_file_size_bytes;
-  };
-
-  function verifyFileSize(input) {
-    const max_size_mb = getMaxFileSize() / 1024 / 1024;
-    const fileSize = input.files[0].size;
-    const errorMessage = document.getElementById("errorMessage");
-
-    if (fileSize > getMaxFileSize(false)) {
-        input.value = ''; // Limpar o campo de entrada para que o usuário possa selecionar novamente
-        errorMessage.innerHTML = `O tamanho máximo permitido é ${getMaxFileSize(true)}MB. Por favor, selecione um arquivo menor.`;
-    } else {
-        errorMessage.innerHTML = '';
-    }
-    const genAltBtn = document.getElementById("gen-alt-btn");
-    if (input.value != "") {
-      genAltBtn.classList.remove("d-none");
-    } else {
-      genAltBtn.classList.add("d-none");
-    }
-  }
-
-
-  function createSimilarMovieTitleOption(movie) {
-          const li = document.createElement('li');
-          const btn = document.createElement('button');
-          btn.type = "button";
-          const option_class_list = ["btn", "btn-link","link-light"]
-          btn.classList.add(...option_class_list);
-          btn.addEventListener("click", function () {
-              document.getElementById('title').value = movie.title;
-          })
-          btn.textContent = movie.title;
-          li.appendChild(btn);
-          return li;
-    }
-
-  function fetchSimilarTitles() {
-      const userInput = document.getElementById('title').value;
-      const url = '/movies/search?title='
-      const similarMovieDiv = document.getElementById('similar_movies');
-
-      function clearMoviesDisplay() {
-        similarMovieDiv.innerHTML = '';
-      }
-
-      if (userInput.length > 2) {
-        fetch(`${url}${encodeURIComponent(userInput)}`)
-        .then(response => response.json())
-        .then(data => {
-            clearMoviesDisplay()
-            data.forEach(movie => {
-                let optionMovieTitle = createSimilarMovieTitleOption(movie)
-                similarMovieDiv.appendChild(optionMovieTitle);
-            })
-        });
-      }
-      else {
-        clearMoviesDisplay()
-      }
-  }
-
-  async function fetchImageAltText(e) {
-    const btn = e.target;
-    
-    const image_input = document.getElementById("movie_poster");
-    const image_alt = document.getElementById("image_alt");
-    
-    // prevent accidental overwriting of existing
-    // image alt text
-    let confirmation = true;
-    if (image_alt.value != "") {
-      confirmation = confirm("Substituir descrição atual?");
-    }
-    if (!confirmation) {
-      return;
-    }
-
-    const form = new FormData();
-    form.append("image", image_input.files[0]);
-
-    btn.disabled = true;
-    const response = await fetch("/screening/image/describe", {
-      method: "POST",
-      body: form
-    });
-    const payload = await response.json();
-
-    if (!response.ok) {
-      alert(payload.details);
-      if (payload.hasOwnProperty("info")) {
-        console.log(payload.info);
-      }
-    }
-
-    if (response.ok) {
-      image_alt.value = payload.text;
-    }
-
-    btn.disabled = false;
-
-  }
-</script>
-{% endblock %}
+    <div class="mb-3">
+        <label class="form-label" for="screening-description">Body</label>
+        <div class="grow-wrap">
+        <textarea
+            class="form-control"
+            name="description"
+            id="screening-description"
+            >{{ request.form['description'] }}</textarea>
+        </div>
+    </div>
+    <div class="container mb-3 pb-3">
+        <input class="btn btn-primary" type="submit" value="Save">
+        <a id="back-btn" class="btn btn-secondary" href="{{ url_for('screening.index') }}">Voltar</a>
+    </div>
+    </form>
+{%endblock %}
+{% include 'screening/form_js.html' %}

--- a/flask_backend/templates/screening/create.html
+++ b/flask_backend/templates/screening/create.html
@@ -64,7 +64,7 @@
         class="form-control"
         name="image_alt"
         id="image_alt"
-        ></textarea>
+        >{{ request.form['image_alt'] }}</textarea>
   </div>
   <div class="mb-3">
     <label class="form-label">Status do cadastro</label>

--- a/flask_backend/templates/screening/create.html
+++ b/flask_backend/templates/screening/create.html
@@ -42,14 +42,21 @@
   <ul class="mb-3" class="" id="similar_movies">
   </ul>
   <div class="mb-3">
-    <label for="movie_poster" class="form-label">Imagem do filme</label>
+    <div class="d-flex mb-2 align-items-center">
+      <label for="movie_poster" class="form-label mb-0 me-3">Imagem do filme</label>
+      <button type="button" id="gen-alt-btn"
+      class="btn btn-secondary d-none"
+      onclick="fetchImageAltText()"
+      >
+        Gerar alt text
+      </button>
+    </div>
     <input class="form-control" name="movie_poster" type="file" id="movie_poster" onchange="verifyFileSize(this)" accept="image/*">
     <p class="form-text">
       <span id="file-limit-label"></span>
       <span class="text-danger d-block" id="errorMessage"></span>
     </p>
   </div>
-
   <div class="mb-3">
     <label class="form-label">Status do cadastro</label>
     <div class="form-check">
@@ -130,6 +137,12 @@
     } else {
         errorMessage.innerHTML = '';
     }
+    const genAltBtn = document.getElementById("gen-alt-btn");
+    if (input.value != "") {
+      genAltBtn.classList.remove("d-none");
+    } else {
+      genAltBtn.classList.add("d-none");
+    }
   }
 
 
@@ -170,6 +183,17 @@
       else {
         clearMoviesDisplay()
       }
+  }
+
+  function fetchImageAltText() {
+    const image_input = document.getElementById("movie_poster");
+    const form = new FormData();
+    form.append("image", image_input.files[0]);
+    
+    fetch("/screening/image/describe", {
+      method: "POST",
+      body: form
+    });
   }
 </script>
 {% endblock %}

--- a/flask_backend/templates/screening/form_js.html
+++ b/flask_backend/templates/screening/form_js.html
@@ -1,0 +1,172 @@
+<script>
+  function removeScreening(e) {
+      const screeningWrapper = document.getElementById("screenings");
+      if (screeningWrapper.childElementCount == 2) return;
+      e.parentElement.remove();
+  }
+
+  function getMaxFileSize(in_mb) {
+      const max_file_size_bytes = {{ max_file_size }};
+      if (in_mb) {
+          return max_file_size_bytes / 1024 / 1024;
+      }
+      return max_file_size_bytes;
+  };
+
+    function toggleGenAltBtn(_input) {
+        let input;
+        if (!_input) {
+            input = document.getElementById("movie_poster");
+        } else {
+            input = _input;
+        }
+        const genAltBtn = document.getElementById("gen-alt-btn");
+        if (input.value != "") {
+        genAltBtn.classList.remove("d-none");
+        } else {
+        genAltBtn.classList.add("d-none");
+        }
+    }
+
+  function verifyFileSize(input) {
+      const max_size_mb = getMaxFileSize() / 1024 / 1024;
+      const fileSize = input.files[0].size;
+      const errorMessage = document.getElementById("errorMessage");
+
+      if (fileSize > getMaxFileSize(false)) {
+          input.value = ''; // Limpar o campo de entrada para que o usuário possa selecionar novamente
+          errorMessage.innerHTML = `O tamanho máximo permitido é ${getMaxFileSize(true)}MB. Por favor, selecione um arquivo menor.`;
+      } else {
+          errorMessage.innerHTML = '';
+      }
+      toggleGenAltBtn(input);
+  }
+
+  function createSimilarMovieTitleOption(movie) {
+      const li = document.createElement('li');
+      const btn = document.createElement('button');
+      btn.type = "button";
+      const option_class_list = ["btn", "btn-link","link-light"]
+      btn.classList.add(...option_class_list);
+      btn.addEventListener("click", function () {
+          document.getElementById('title').value = movie.title;
+      })
+      btn.textContent = movie.title;
+      li.appendChild(btn);
+      return li;
+  }
+
+  function fetchSimilarTitles() {
+      const userInput = document.getElementById('title').value;
+      const url = '/movies/search?title='
+      const similarMovieDiv = document.getElementById('similar_movies');
+
+      function clearMoviesDisplay() {
+          similarMovieDiv.innerHTML = '';
+      }
+
+      if (userInput.length > 2) {
+          fetch(`${url}${encodeURIComponent(userInput)}`)
+          .then(response => response.json())
+          .then(data => {
+              clearMoviesDisplay()
+              data.forEach(movie => {
+                  let optionMovieTitle = createSimilarMovieTitleOption(movie)
+                  similarMovieDiv.appendChild(optionMovieTitle);
+              })
+          });
+      }
+      else {
+          clearMoviesDisplay()
+      }
+  }
+
+  async function fetchImageAltText(e) {
+      const btn = e.target;
+
+      const image_input = document.getElementById("movie_poster");
+      const image_alt = document.getElementById("image_alt");
+
+      // prevent accidental overwriting of existing
+      // image alt text
+      let confirmation = true;
+      if (image_alt.value != "") {
+          confirmation = confirm("Substituir descrição atual?");
+      }
+      if (!confirmation) {
+          return;
+      }
+
+      const form = new FormData();
+      form.append("image", image_input.files[0]);
+
+      btn.disabled = true;
+      const response = await fetch("/screening/image/describe", {
+          method: "POST",
+          body: form
+      });
+      const payload = await response.json();
+
+      if (!response.ok) {
+          alert(payload.details);
+          if (payload.hasOwnProperty("info")) {
+              console.log(payload.info);
+          }
+      }
+
+      if (response.ok) {
+          image_alt.value = payload.text;
+      }
+
+      btn.disabled = false;
+  }
+
+  async function populateImageField(image_url) {
+    if (image_url === null) {
+        return;
+    }
+    const fileInput = document.getElementById("movie_poster");
+    const filename = image_url.split("/").at(-1);
+    const response = await fetch(image_url);
+    if (!response.ok) {
+        return;
+    }
+    const contentType = response.headers['content-type'];
+    if (contentType === null || contentType === "") {
+        return;
+    }
+    const blob = await response.blob();
+    const file = new File([blob], filename, { type: contentType, lastModified: new Date().getTime()}, 'utf-8');
+    const container = new DataTransfer();
+    container.items.add(file);
+    fileInput.files = container.files;
+  }
+
+    window.onload = async () => {
+        const description = document.getElementById("screening-description");
+        description.style.height = `${description.scrollHeight}px`;
+        const backBtn = document.getElementById("back-btn");
+        backBtn.addEventListener("click", (e) => {
+            const proceed = confirm("Alterações não salvas serão perdidas. Prosseguir?");
+            if (!proceed) {
+                e.preventDefault();
+                return;
+            }
+        });
+        const addScreeningBtn = document.getElementById("add-screening-btn");
+        addScreeningBtn.addEventListener("click", (e) => {
+            const screeningWrapper = document.getElementById("screenings");
+            const screeningDiv = screeningWrapper.lastElementChild;
+            const newScreeningDiv = screeningDiv.cloneNode(true);
+            screeningWrapper.appendChild(newScreeningDiv);
+        });
+
+        document.getElementById(
+            "file-limit-label"
+        ).innerHTML = `Tamanho máximo de imagem de ${getMaxFileSize(true)}mb!`;
+
+        await populateImageField("{{ image }}");
+
+        toggleGenAltBtn();
+    };
+</script>

--- a/flask_backend/templates/screening/index.html
+++ b/flask_backend/templates/screening/index.html
@@ -37,13 +37,11 @@
         class="mb-5 clearfix"
         style="min-height: {{screening_date['min_height']}}px"
       >
-        <img
-          class="img-fluid rounded float-sm-start shadow-sm mb-3 me-0 me-sm-3"
-          src="{{ screening_date['image'] }}"
-          width="{{ screening_date['image_display_width'] }}"
-          loading="lazy"
-        />
-        {% else %}
+        <img class="img-fluid rounded float-sm-start shadow-sm mb-3 me-0
+        me-sm-3" src="{{ screening_date['image'] }}" width="{{
+        screening_date['image_display_width'] }}" loading="lazy" {% if
+        screening_date['image_alt'] %} alt="{{ screening_date['image_alt'] }}"
+        title="{{ screening_date['image_alt'] }}" {% endif %} /> {% else %}
       </li>
 
       <li class="mb-5">
@@ -72,7 +70,6 @@
             Descartar
           </button>
           {% endif %}
-
         </div>
         {% if screening_date['times']|length %}
         <div class="mb-3 d-flex align-items-center">

--- a/flask_backend/templates/screening/update.html
+++ b/flask_backend/templates/screening/update.html
@@ -37,15 +37,45 @@
     />
   </div>
   <div class="mb-3">
-    <label for="movie_poster" class="form-label">Imagem do filme</label>
+    <div class="d-flex mb-2 align-items-center">
+      <label for="movie_poster" class="form-label mb-0 me-3"
+        >Imagem do filme</label
+      >
+      <button
+        type="button"
+        id="gen-alt-btn"
+        class="btn btn-secondary d-none"
+        onclick="fetchImageAltText(event)"
+      >
+        Gerar alt text
+      </button>
+    </div>
     <input
       class="form-control"
       name="movie_poster"
       type="file"
       id="movie_poster"
+      onchange="verifyFileSize(this)"
+      accept="image/*"
     />
+    <p class="form-text">
+      <span id="file-limit-label"></span>
+      <span class="text-danger d-block" id="errorMessage"></span>
+    </p>
   </div>
-
+  <div class="mb-3">
+    <label class="form-label" for="image_alt"
+      >Descrição do poster (texto alternativo)</label
+    >
+    <textarea
+      placeholder="Descreva a imagem adicionada acima"
+      class="form-control"
+      name="image_alt"
+      id="image_alt"
+    >
+{{ request.form['image_alt'] }}</textarea
+    >
+  </div>
   <div class="mb-3">
     <label class="form-label">Status do cadastro</label>
     <div class="form-check">
@@ -86,35 +116,4 @@
     >
   </div>
 </form>
-<script>
-  function removeScreening(e) {
-    const screeningWrapper = document.getElementById("screenings");
-    if (screeningWrapper.childElementCount == 2) return;
-    e.parentElement.remove();
-  }
-  window.onload = () => {
-    const description = document.getElementById("screening-description");
-    description.style.height = `${description.scrollHeight}px`;
-    const backBtn = document.getElementById("back-btn");
-    backBtn.addEventListener("click", (e) => {
-      const proceed = confirm(
-        "Alterações não salvas serão perdidas. Prosseguir?"
-      );
-      if (!proceed) {
-        e.preventDefault();
-        return;
-      }
-    });
-  };
-  const addScreeningBtn = document.getElementById("add-screening-btn");
-  addScreeningBtn.addEventListener("click", (e) => {
-    const screeningWrapper = document.getElementById("screenings");
-
-    const screeningDiv = screeningWrapper.lastElementChild;
-
-    const newScreeningDiv = screeningDiv.cloneNode(true);
-
-    screeningWrapper.appendChild(newScreeningDiv);
-  });
-</script>
-{% endblock %}
+{% endblock %} {% include 'screening/form_js.html' %}


### PR DESCRIPTION
Este PR implementa o proposto nos issues #60 e #59 , permitindo que o admin adicione "texto alternativo" para as imagens das `screening`s.

O texto alternativo é o equivalente à propriedade `alt` das tags `<img>`, onde é preenchido uma descrição da imagem para ajudar pessoas com deficiência visual/baixa visão.

Além disso, foi criada uma integração com a API Gemini do google, que permite enviar as imagens para uma geração automática da descrição das imagens.