### PR TITLE
Fix | Bloquear registro de cinemas duplicados

### DIFF
--- a/flask_backend/db.py
+++ b/flask_backend/db.py
@@ -46,11 +46,30 @@ def seed_db():
         screening_seeds,
         user_seeds,
     )
+    
+    try:
+        screening_seeds.create_screenings(db_session)
+    except IntegrityError:
+        db_session.rollback()
+        print("Screenings already registered. Skipping...")
 
-    cinema_seeds.create_cinemas(db_session)
-    movie_seeds.create_movies(db_session)
-    screening_seeds.create_screenings(db_session)
-    user_seeds.create_user(db_session)
+    try:
+        cinema_seeds.create_cinemas(db_session)
+    except IntegrityError:
+        db_session.rollback()
+        print("Cinemas already registered. Skipping...")
+
+    try:
+        movie_seeds.create_movies(db_session)
+    except IntegrityError:
+        db_session.rollback()
+        print("Movie already registered. Skipping...")
+
+    try:
+        user_seeds.create_user(db_session)        
+    except IntegrityError:
+        db_session.rollback()
+        print("Users already registered. Skipping...")
 
 
 def init_app(app):

--- a/flask_backend/db.py
+++ b/flask_backend/db.py
@@ -63,7 +63,7 @@ def seed_db():
         movie_seeds.create_movies(db_session)
     except IntegrityError:
         db_session.rollback()
-        print("Movie already registered. Skipping...")
+        print("Movies already registered. Skipping...")
 
     try:
         user_seeds.create_user(db_session)        


### PR DESCRIPTION
Correção da issue #37 

## Motivação
Evitar erros ao rodar o db-seed.

## Solução
Utilizar o mesmo código utilizado no seed de produção e dar rollback se ocorrer um problema em cada seed.

```
    try:
        screening_seeds.create_screenings(db_session)
    except IntegrityError:
        db_session.rollback()
        print("Screenings already registered. Skipping...")

    try:
        cinema_seeds.create_cinemas(db_session)
    except IntegrityError:
        db_session.rollback()
        print("Cinemas already registered. Skipping...")

    try:
        movie_seeds.create_movies(db_session)
    except IntegrityError:
        db_session.rollback()
        print("Movie already registered. Skipping...")

    try:
        user_seeds.create_user(db_session)        
    except IntegrityError:
        db_session.rollback()
        print("Users already registered. Skipping...")
```

## Revisão
@guites 
