### PR TITLE
#60 uso de ia para gerar descricao de imagens

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -3,6 +3,9 @@ WORKDIR /app
 RUN apt-get update
 RUN apt-get install locales locales-all -y
 
+RUN apt update && apt install tzdata -y
+ENV TZ="America/Sao_Paulo"
+
 ENV LC_ALL pt_BR.UTF-8
 ENV LANG pt_BR.UTF-8
 ENV LANGUAGE pt_BR.UTF-8

--- a/example.env
+++ b/example.env
@@ -4,3 +4,4 @@ ACME_EMAIL=administrator@email.com # used to register the ssl certificate for ht
 ADMIN_PROD_USERNAME=adminusername
 ADMIN_PROD_PWD=adminpassword
 IMGBB_API_KEY=imgbbapikey # api-key from https://api.imgbb.com/
+GEMINI_API_KEY=mygeminiapikey

--- a/flask_backend/env_config.py
+++ b/flask_backend/env_config.py
@@ -8,4 +8,7 @@ APP_ENVIRONMENT = config("APP_ENVIRONMENT", default=EnvironmentEnum.DEVELOPMENT)
 ADMIN_PROD_USERNAME = config("ADMIN_PROD_USERNAME", default="cinemaempoa")
 ADMIN_PROD_PWD = config("ADMIN_PROD_PWD", default="secret-pwd")
 UPLOAD_DIR = config("UPLOAD_DIR", None)
-IMGBB_API_KEY = config("IMGBB_API_KEY", default="invalid-key") # api-key from https://api.imgbb.com/
+IMGBB_API_KEY = config(
+    "IMGBB_API_KEY", default="invalid-key"
+)  # api-key from https://api.imgbb.com/
+GEMINI_API_KEY = config("GEMINI_API_KEY", None)

--- a/flask_backend/models.py
+++ b/flask_backend/models.py
@@ -41,6 +41,7 @@ class Screening(Base):
     url = Column(String, nullable=True)
     # TODO: should image and description belong to the movie?
     image = Column(String, nullable=True)
+    image_alt = Column(String, nullable=True)
     description = Column(String, nullable=False)
     # TODO: maybe change this to a _status_ enum?
     draft = Column(Boolean, nullable=False, default=False)

--- a/flask_backend/repository/screenings.py
+++ b/flask_backend/repository/screenings.py
@@ -45,12 +45,14 @@ def create(
     image_width: Optional[int],
     image_height: Optional[int],
     is_draft: Optional[bool] = False,
+    image_alt: Optional[bool] = None,
 ) -> Screening:
     screening = Screening(
         movie_id=movie_id,
         cinema_id=cinema_id,
         dates=screening_dates,
         image=image,
+        image_alt=image_alt,
         image_width=image_width,
         image_height=image_height,
         description=description,

--- a/flask_backend/repository/screenings.py
+++ b/flask_backend/repository/screenings.py
@@ -86,10 +86,13 @@ def update(
     image_width: Optional[int],
     image_height: Optional[int],
     is_draft: Optional[bool] = False,
+    image_alt: Optional[str] = None,
 ) -> None:
     screening.movie_id = movie_id
     screening.description = description
     screening.draft = is_draft
+    if image_alt:
+        screening.image_alt = image_alt
     if image:
         screening.image = image
         screening.image_width = image_width

--- a/flask_backend/routes/screening.py
+++ b/flask_backend/routes/screening.py
@@ -89,6 +89,7 @@ def index():
                 {
                     "times": screening_times,
                     "image": screening.image,
+                    "image_alt": screening.image_alt,
                     "min_height": minHeight,
                     "image_display_width": imgDisplayWidth,
                     "title": screening.movie.title,
@@ -122,6 +123,7 @@ def create():
         cinema_id = request.form.get("cinema_id")
         screening_dates = request.form.getlist("screening_dates")
         status = request.form.get("status")
+        image_alt = request.form.get("image_alt")
         error = None
 
         if not movie_title:
@@ -169,6 +171,7 @@ def create():
                 image_width,
                 image_height,
                 status == "draft",
+                image_alt,
             )
             flash(f"Sessão «{movie_title}» criada com sucesso!", "success")
             return redirect(url_for("screening.index"))
@@ -411,12 +414,12 @@ def describe_image():
     if request.method != "POST":
         abort(405)
     if "image" not in request.files:
-        jsonify({"details": "Imagem não encontrada."}), 400
+        return jsonify({"details": "Imagem não encontrada."}), 400
     image = request.files["image"]
     try:
         gemini = Gemini()
     except ValueError:
-        jsonify({"details": "Chave de API Gemini não configurada."}), 500
+        return jsonify({"details": "Chave de API Gemini não configurada."}), 500
 
     prompt_text = "Descreva essa imagem de forma a auxiliar uma pessoa com dificuldade de visão a entender o seu contexto, em português brasileiro."
     prompt_response = gemini.prompt_image(image, prompt_text)

--- a/flask_backend/routes/screening.py
+++ b/flask_backend/routes/screening.py
@@ -225,7 +225,7 @@ def publish(id):
 @login_required
 def update(id):
     screening = get_screening_by_id(id)
-
+    image = None
     if not screening:
         abort(404)
 
@@ -285,7 +285,12 @@ def update(id):
             flash(f"Sessão «{movie_title}» atualizada com sucesso!", "success")
             return redirect(url_for("screening.index"))
 
-    return render_template("screening/update.html", screening=screening, max_file_size=current_app.config["MAX_CONTENT_LENGTH"])
+    return render_template(
+        "screening/update.html",
+        current_movie_poster=image or screening.image,
+        screening=screening,
+        max_file_size=current_app.config["MAX_CONTENT_LENGTH"]
+    )
 
 
 @bp.route("/screening/<int:id>/delete", methods=("POST",))
@@ -432,7 +437,15 @@ def describe_image():
                 "info": prompt_response,
             }
         )
-    image_description = prompt_response["candidates"][0]["content"]["parts"][0]["text"]
+    candidate = prompt_response["candidates"][0]
+    if not "content" in candidate:
+        return jsonify(
+            {
+                "details": "Não foi possível gerar uma descrição para a imagem.",
+                "info": prompt_response,
+            }
+        )
+    image_description = candidate["content"]["parts"][0]["text"]
     return jsonify(text=image_description.strip())
 
 

--- a/flask_backend/routes/screening.py
+++ b/flask_backend/routes/screening.py
@@ -234,6 +234,7 @@ def update(id):
         description = request.form.get("description")
         screening_dates = request.form.getlist("screening_dates")
         status = request.form.get("status")
+        image_alt = request.form.get("image_alt")
         error = None
 
         if not movie_title:
@@ -279,11 +280,12 @@ def update(id):
                 image_width,
                 image_height,
                 status == "draft",
+                image_alt
             )
             flash(f"Sessão «{movie_title}» atualizada com sucesso!", "success")
             return redirect(url_for("screening.index"))
 
-    return render_template("screening/update.html", screening=screening)
+    return render_template("screening/update.html", screening=screening, max_file_size=current_app.config["MAX_CONTENT_LENGTH"])
 
 
 @bp.route("/screening/<int:id>/delete", methods=("POST",))

--- a/flask_backend/service/gemini_api.py
+++ b/flask_backend/service/gemini_api.py
@@ -1,0 +1,47 @@
+import base64
+
+import requests
+
+from flask_backend.env_config import GEMINI_API_KEY
+
+
+class Gemini:
+    """Interacts with google's Gemini API
+    https://ai.google.dev/gemini-api/docs"""
+
+    def __init__(self):
+        if GEMINI_API_KEY is None:
+            raise ValueError("Invalid Gemini API key")
+        self.headers = {"Content-Type": "application/json"}
+        self.api_key = GEMINI_API_KEY
+        self.models = {
+            "gemini-pro-vision": "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision"
+        }
+
+    def _get_url(self, model, resource):
+        return f"{self.models[model]}:{resource}?key={self.api_key}"
+
+    def prompt_image(self, image, text):
+        """Based on https://ai.google.dev/gemini-api/docs/get-started/rest#text-and-image_input"""
+        payload = {
+            "contents": [
+                {
+                    "parts": [
+                        {"text": text},
+                        {
+                            "inline_data": {
+                                "mime_type": "image/jpeg",
+                                "data": base64.b64encode(image.read()).decode("utf-8"),
+                            }
+                        },
+                    ]
+                }
+            ]
+        }
+        r = requests.post(
+            self._get_url("gemini-pro-vision", "generateContent"),
+            json=payload,
+            headers=self.headers,
+        )
+        r.raise_for_status()
+        return r.json()

--- a/flask_backend/service/gemini_api.py
+++ b/flask_backend/service/gemini_api.py
@@ -15,7 +15,8 @@ class Gemini:
         self.headers = {"Content-Type": "application/json"}
         self.api_key = GEMINI_API_KEY
         self.models = {
-            "gemini-pro-vision": "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision"
+            "gemini-pro-vision": "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision",  # this one seems to be discontinued
+            "gemini-1.5-flash-latest": "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest",
         }
 
     def _get_url(self, model, resource):
@@ -39,7 +40,7 @@ class Gemini:
             ]
         }
         r = requests.post(
-            self._get_url("gemini-pro-vision", "generateContent"),
+            self._get_url("gemini-1.5-flash-latest", "generateContent"),
             json=payload,
             headers=self.headers,
         )

--- a/flask_backend/templates/screening/create.html
+++ b/flask_backend/templates/screening/create.html
@@ -104,8 +104,12 @@
     e.parentElement.remove();
   }
   window.onload = () => {
+
+    // Adjusts the "Body" textarea height to show all written text
     const description = document.getElementById("screening-description");
     description.style.height = `${description.scrollHeight}px`;
+
+    // Prevents accidental click on "Voltar" button
     const backBtn = document.getElementById('back-btn');
     backBtn.addEventListener("click", (e) => {
       const proceed = confirm("Alterações não salvas serão perdidas. Prosseguir?");
@@ -114,16 +118,16 @@
         return;
       }
     });
+
+    // Duplicates latest screening by clicking on the "Outra exibição" button
     const addScreeningBtn = document.getElementById("add-screening-btn");
     addScreeningBtn.addEventListener("click", (e) => {
       const screeningWrapper = document.getElementById("screenings");
-
       const screeningDiv = screeningWrapper.lastElementChild;
-
       const newScreeningDiv = screeningDiv.cloneNode(true);
-
       screeningWrapper.appendChild(newScreeningDiv);
     });
+
     document.getElementById("file-limit-label").innerHTML = `Tamanho máximo de imagem de ${getMaxFileSize(true)}mb!`;
   };
 

--- a/flask_backend/templates/screening/create.html
+++ b/flask_backend/templates/screening/create.html
@@ -46,7 +46,7 @@
       <label for="movie_poster" class="form-label mb-0 me-3">Imagem do filme</label>
       <button type="button" id="gen-alt-btn"
       class="btn btn-secondary d-none"
-      onclick="fetchImageAltText()"
+      onclick="fetchImageAltText(event)"
       >
         Gerar alt text
       </button>
@@ -56,6 +56,15 @@
       <span id="file-limit-label"></span>
       <span class="text-danger d-block" id="errorMessage"></span>
     </p>
+  </div>
+  <div class="mb-3">
+      <label class="form-label" for="image_alt">Descrição do poster (texto alternativo)</label>
+      <textarea
+        placeholder="Descreva a imagem adicionada acima"
+        class="form-control"
+        name="image_alt"
+        id="image_alt"
+        ></textarea>
   </div>
   <div class="mb-3">
     <label class="form-label">Status do cadastro</label>
@@ -185,15 +194,45 @@
       }
   }
 
-  function fetchImageAltText() {
+  async function fetchImageAltText(e) {
+    const btn = e.target;
+    
     const image_input = document.getElementById("movie_poster");
+    const image_alt = document.getElementById("image_alt");
+    
+    // prevent accidental overwriting of existing
+    // image alt text
+    let confirmation = true;
+    if (image_alt.value != "") {
+      confirmation = confirm("Substituir descrição atual?");
+    }
+    if (!confirmation) {
+      return;
+    }
+
     const form = new FormData();
     form.append("image", image_input.files[0]);
-    
-    fetch("/screening/image/describe", {
+
+    btn.disabled = true;
+    const response = await fetch("/screening/image/describe", {
       method: "POST",
       body: form
     });
+    const payload = await response.json();
+
+    if (!response.ok) {
+      alert(payload.details);
+      if (payload.hasOwnProperty("info")) {
+        console.log(payload.info);
+      }
+    }
+
+    if (response.ok) {
+      image_alt.value = payload.text;
+    }
+
+    btn.disabled = false;
+
   }
 </script>
 {% endblock %}

--- a/flask_backend/templates/screening/create.html
+++ b/flask_backend/templates/screening/create.html
@@ -64,7 +64,7 @@
         class="form-control"
         name="image_alt"
         id="image_alt"
-        ></textarea>
+        >{{ request.form['image_alt'] }}</textarea>
   </div>
   <div class="mb-3">
     <label class="form-label">Status do cadastro</label>

--- a/flask_backend/templates/screening/create.html
+++ b/flask_backend/templates/screening/create.html
@@ -42,14 +42,21 @@
   <ul class="mb-3" class="" id="similar_movies">
   </ul>
   <div class="mb-3">
-    <label for="movie_poster" class="form-label">Imagem do filme</label>
+    <div class="d-flex mb-2 align-items-center">
+      <label for="movie_poster" class="form-label mb-0 me-3">Imagem do filme</label>
+      <button type="button" id="gen-alt-btn"
+      class="btn btn-secondary d-none"
+      onclick="fetchImageAltText()"
+      >
+        Gerar alt text
+      </button>
+    </div>
     <input class="form-control" name="movie_poster" type="file" id="movie_poster" onchange="verifyFileSize(this)" accept="image/*">
     <p class="form-text">
       <span id="file-limit-label"></span>
       <span class="text-danger d-block" id="errorMessage"></span>
     </p>
   </div>
-
   <div class="mb-3">
     <label class="form-label">Status do cadastro</label>
     <div class="form-check">
@@ -130,6 +137,12 @@
     } else {
         errorMessage.innerHTML = '';
     }
+    const genAltBtn = document.getElementById("gen-alt-btn");
+    if (input.value != "") {
+      genAltBtn.classList.remove("d-none");
+    } else {
+      genAltBtn.classList.add("d-none");
+    }
   }
 
 
@@ -170,6 +183,17 @@
       else {
         clearMoviesDisplay()
       }
+  }
+
+  function fetchImageAltText() {
+    const image_input = document.getElementById("movie_poster");
+    const form = new FormData();
+    form.append("image", image_input.files[0]);
+    
+    fetch("/screening/image/describe", {
+      method: "POST",
+      body: form
+    });
   }
 </script>
 {% endblock %}

--- a/flask_backend/templates/screening/index.html
+++ b/flask_backend/templates/screening/index.html
@@ -37,13 +37,11 @@
         class="mb-5 clearfix"
         style="min-height: {{screening_date['min_height']}}px"
       >
-        <img
-          class="img-fluid rounded float-sm-start shadow-sm mb-3 me-0 me-sm-3"
-          src="{{ screening_date['image'] }}"
-          width="{{ screening_date['image_display_width'] }}"
-          loading="lazy"
-        />
-        {% else %}
+        <img class="img-fluid rounded float-sm-start shadow-sm mb-3 me-0
+        me-sm-3" src="{{ screening_date['image'] }}" width="{{
+        screening_date['image_display_width'] }}" loading="lazy" {% if
+        screening_date['image_alt'] %} alt="{{ screening_date['image_alt'] }}"
+        title="{{ screening_date['image_alt'] }}" {% endif %} /> {% else %}
       </li>
 
       <li class="mb-5">
@@ -72,7 +70,6 @@
             Descartar
           </button>
           {% endif %}
-
         </div>
         {% if screening_date['times']|length %}
         <div class="mb-3 d-flex align-items-center">

--- a/flask_backend/templates/screening/update.html
+++ b/flask_backend/templates/screening/update.html
@@ -38,15 +38,16 @@
   </div>
   <div class="mb-3">
     <div class="d-flex mb-2 align-items-center">
-      <label for="movie_poster" class="form-label">Imagem do filme</label>
+      <label for="movie_poster" class="form-label mb-0 me-3">Imagem do filme</label>
       <button type="button" id="gen-alt-btn"
-        class="btn btn-secondary d-none"
+        class="btn btn-secondary"
         onclick="fetchImageAltText(event)"
         >
         Gerar alt text
       </button>
     </div>
     <input class="form-control" name="movie_poster" type="file" id="movie_poster" onchange="verifyFileSize(this)" accept="image/*" />
+    <input type="hidden" name="current_movie_poster" id="current_movie_poster" value="{{ current_movie_poster }}"/>
     <p class="form-text">
       <span id="file-limit-label"></span>
       <span class="text-danger d-block" id="errorMessage"></span>
@@ -156,18 +157,21 @@
     } else {
         errorMessage.innerHTML = '';
     }
-    const genAltBtn = document.getElementById("gen-alt-btn");
-    if (input.value != "") {
-      genAltBtn.classList.remove("d-none");
-    } else {
-      genAltBtn.classList.add("d-none");
-    }
+  }
+
+  async function getFileFromUrl(url, name, defaultType = 'image/jpeg'){
+    const response = await fetch(url);
+    const data = await response.blob();
+    return new File([data], name, {
+      type: data.type || defaultType,
+    });
   }
 
   async function fetchImageAltText(e) {
     const btn = e.target;
 
     const image_input = document.getElementById("movie_poster");
+    const current_movie_poster = document.getElementById("current_movie_poster")
     const image_alt = document.getElementById("image_alt");
 
     // prevent accidental overwriting of existing
@@ -181,7 +185,14 @@
     }
 
     const form = new FormData();
-    form.append("image", image_input.files[0]);
+
+    // if the user selected a new file via input,
+    // use that
+    if (image_input.files.length > 0) {
+      form.append("image", image_input.files[0]);
+    } else if (current_movie_poster.value != "") {
+      form.append('image', await getFileFromUrl(current_movie_poster.value))
+    }
 
     btn.disabled = true;
     const response = await fetch("/screening/image/describe", {

--- a/flask_backend/templates/screening/update.html
+++ b/flask_backend/templates/screening/update.html
@@ -37,15 +37,30 @@
     />
   </div>
   <div class="mb-3">
-    <label for="movie_poster" class="form-label">Imagem do filme</label>
-    <input
-      class="form-control"
-      name="movie_poster"
-      type="file"
-      id="movie_poster"
-    />
+    <div class="d-flex mb-2 align-items-center">
+      <label for="movie_poster" class="form-label">Imagem do filme</label>
+      <button type="button" id="gen-alt-btn"
+        class="btn btn-secondary d-none"
+        onclick="fetchImageAltText(event)"
+        >
+        Gerar alt text
+      </button>
+    </div>
+    <input class="form-control" name="movie_poster" type="file" id="movie_poster" onchange="verifyFileSize(this)" accept="image/*" />
+    <p class="form-text">
+      <span id="file-limit-label"></span>
+      <span class="text-danger d-block" id="errorMessage"></span>
+    </p>
   </div>
-
+    <div class="mb-3">
+      <label class="form-label" for="image_alt">Descrição do poster (texto alternativo)</label>
+      <textarea
+        placeholder="Descreva a imagem adicionada acima"
+        class="form-control"
+        name="image_alt"
+        id="image_alt"
+        >{{ request.form['image_alt'] or screening['image_alt'] }}</textarea>
+  </div>
   <div class="mb-3">
     <label class="form-label">Status do cadastro</label>
     <div class="form-check">
@@ -93,8 +108,12 @@
     e.parentElement.remove();
   }
   window.onload = () => {
+
+    // Adjusts the "Body" textarea height to show all written text
     const description = document.getElementById("screening-description");
     description.style.height = `${description.scrollHeight}px`;
+
+    // Prevents accidental click on "Voltar" button
     const backBtn = document.getElementById("back-btn");
     backBtn.addEventListener("click", (e) => {
       const proceed = confirm(
@@ -105,16 +124,85 @@
         return;
       }
     });
+
+    // Duplicates latest screening by clicking on the "Outra exibição" button
+    const addScreeningBtn = document.getElementById("add-screening-btn");
+    addScreeningBtn.addEventListener("click", (e) => {
+      const screeningWrapper = document.getElementById("screenings");
+      const screeningDiv = screeningWrapper.lastElementChild;
+      const newScreeningDiv = screeningDiv.cloneNode(true);
+      screeningWrapper.appendChild(newScreeningDiv);
+    });
+
+    document.getElementById("file-limit-label").innerHTML = `Tamanho máximo de imagem de ${getMaxFileSize(true)}mb!`;
   };
-  const addScreeningBtn = document.getElementById("add-screening-btn");
-  addScreeningBtn.addEventListener("click", (e) => {
-    const screeningWrapper = document.getElementById("screenings");
 
-    const screeningDiv = screeningWrapper.lastElementChild;
+  function getMaxFileSize(in_mb) {
+    const max_file_size_bytes = {{ max_file_size }};
+    if (in_mb) {
+      return max_file_size_bytes / 1024 / 1024;
+    }
+    return max_file_size_bytes;
+  };
 
-    const newScreeningDiv = screeningDiv.cloneNode(true);
+  function verifyFileSize(input) {
+    const max_size_mb = getMaxFileSize() / 1024 / 1024;
+    const fileSize = input.files[0].size;
+    const errorMessage = document.getElementById("errorMessage");
 
-    screeningWrapper.appendChild(newScreeningDiv);
-  });
+    if (fileSize > getMaxFileSize(false)) {
+        input.value = ''; // Limpar o campo de entrada para que o usuário possa selecionar novamente
+        errorMessage.innerHTML = `O tamanho máximo permitido é ${getMaxFileSize(true)}MB. Por favor, selecione um arquivo menor.`;
+    } else {
+        errorMessage.innerHTML = '';
+    }
+    const genAltBtn = document.getElementById("gen-alt-btn");
+    if (input.value != "") {
+      genAltBtn.classList.remove("d-none");
+    } else {
+      genAltBtn.classList.add("d-none");
+    }
+  }
+
+  async function fetchImageAltText(e) {
+    const btn = e.target;
+
+    const image_input = document.getElementById("movie_poster");
+    const image_alt = document.getElementById("image_alt");
+
+    // prevent accidental overwriting of existing
+    // image alt text
+    let confirmation = true;
+    if (image_alt.value != "") {
+      confirmation = confirm("Substituir descrição atual?");
+    }
+    if (!confirmation) {
+      return;
+    }
+
+    const form = new FormData();
+    form.append("image", image_input.files[0]);
+
+    btn.disabled = true;
+    const response = await fetch("/screening/image/describe", {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    if (!response.ok) {
+      alert(payload.details);
+      if (payload.hasOwnProperty("info")) {
+        console.log(payload.info);
+      }
+    }
+
+    if (response.ok) {
+      image_alt.value = payload.text;
+    }
+
+    btn.disabled = false;
+
+  }
 </script>
 {% endblock %}


### PR DESCRIPTION
Este PR implementa o proposto nos issues https://github.com/guites/cinemaempoa/issues/60 e https://github.com/guites/cinemaempoa/issues/59 , permitindo que o admin adicione "texto alternativo" para as imagens das screenings.

O texto alternativo é o equivalente à propriedade alt das tags <img>, onde é preenchido uma descrição da imagem para ajudar pessoas com deficiência visual/baixa visão.

Além disso, foi criada uma integração com a API Gemini do google, que permite enviar as imagens para uma geração automática da descrição das imagens.